### PR TITLE
Fix `Infinity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Dates               | `new Date`          | :warning: `"2016-02-26T16:00:46.589Z
 NaN                 | `NaN`               | :warning: `null`                       | :white_check_mark: `NaN`
 Sparse arrays       | `a=[]; a[2]=0; a`   | :warning: `[null,null,0]`              | :white_check_mark: `var a=Array(3);a[2]=0;a`
 Object properties   | `a=[0,1]; a.b=2; a` | :warning: `[0,1]`                      | :white_check_mark: `var a=[0,1];a.b=2;a`
+Infinity            | `Infinity`          | :warning: `null`                       | :white_check_mark: `Infinity`
 
 ## Example
 

--- a/lib/lave.js
+++ b/lib/lave.js
@@ -131,9 +131,11 @@ export default function(value, options) {
 
       case 'object': if (value !== null) break
       case 'string':
-      case 'number':
       case 'boolean':
         return {type: 'Literal', value}
+      case 'number': return isFinite(value)
+        ? {type: 'Literal', value}
+        : {type: 'Identifier', name: 'Infinity'}
     }
 
     if (expressions.has(value)) return expressions.get(value)

--- a/test.js
+++ b/test.js
@@ -23,7 +23,8 @@ const tests = {
   global:    [ root               , `(0,eval)('this')`                  ],
   slice:     [ [].slice           , `Array.prototype.slice`             ],
   cycle:     [ (a=>a[0]=a)([])    , `var a=[null];a[0]=a;a`             ],
-  dipole:    [ (a=>[a,a])({})     , `var a={};[a,a]`                    ]
+  dipole:    [ (a=>[a,a])({})     , `var a={};[a,a]`                    ],
+  Infinity:  [ Infinity           , `Infinity`                          ]
 }
 
 const format = {compact: true, semicolons: false}


### PR DESCRIPTION
This PR implements support for the `Infinity` identifier.

An alternative is producing `raw` properties on expression nodes and passing `esprima.parse` through to `escodegen.generate` as `options.parse` but this way the dependency is avoided.
