### PR TITLE
add option to disable crawling the global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ By default, lave takes an `object` and returns an abstract syntax tree (AST) rep
   - `expression` (default): Returns code in which the last statement is result expression, such as `var a={};[a, a];`. This is useful when the code is evaluated with [eval][].
   - `function`: Returns the code as a function expression, such as `(function(){var a={};return[a, a]})`. This is useful for inlining as an expression without polluting scope.
   - `module`: Returns the code as an ES6 module export, such as `var a={};export default[a, a];`. This is currently useful for integration with a module build process, such as [Rollup][] or [Babel][] transforms.
+- `globalRefs`: Whether to search the global scope for references. Set this to `false` when the code will be evaluated in a different context.
 
 ## Addenda
 

--- a/lave.js
+++ b/lave.js
@@ -7,7 +7,7 @@ export default function(object, options) {
   var placeholder = Math.random().toString(36).replace(/../, '_')
   var functionPattern = RegExp(`${placeholder}(\\d+)`, 'g')
 
-  let cache = new Globals
+  let cache = new Globals(options.globalRefs)
   let statements = []
 
   let expression = getExpression(object)
@@ -391,7 +391,7 @@ function isNativeFunction(fn) {
   return length === source.length
 }
 
-function Globals() {
+function Globals(recursive) {
   let globals = new Map([
     [NaN, {type: 'Identifier', name: 'NaN'}],
     [null, {type: 'Literal', value: null}],
@@ -410,7 +410,7 @@ function Globals() {
     }]
   ])
 
-  return crawl(globals, (0, eval)('this'))
+  return recursive === false ? globals : crawl(globals, (0, eval)('this'))
 }
 
 function crawl(map, value, object) {

--- a/test.js
+++ b/test.js
@@ -4,6 +4,9 @@ import {equal} from 'assert'
 import escodegen from 'escodegen'
 import lave from '.'
 
+const globalRef = { foo: 23 }
+exports.globalRef = globalRef
+
 const tests = {
   number:    [ 123                           , `123`                                 ],
   negative:  [ -123                          , `-123`                                ],
@@ -28,6 +31,7 @@ const tests = {
   cycleMap:  [ (a=>a.set(0,a))(new Map)      , `var a=new Map([[0]]);a.set(0,a);a`   ],
   cycleSet:  [ (a=>a.add(a).add(0))(new Set) , `var a=new Set();a.add(a);a.add(0);a` ],
   global:    [ root                          , `(0,eval)('this')`                    ],
+  globalRef: [ globalRef                     , `exports.globalRef`                   ],
   slice:     [ [].slice                      , `Array.prototype.slice`               ],
   arrcycle:  [ (a=>a[0]=a)([])               , `var a=[,];a[0]=a;a`                  ],
   objcycle:  [ (a=>a.a=a)({})                , `var a={'a':null};a.a=a;a`            ],
@@ -49,6 +53,9 @@ for (let name in tests) {
     actual ${name}: ${actual}
   `)
 }
+
+options.globalRefs = false
+equal(lave(globalRef, options), `({'foo':23})`)
 
 options.format = 'module'
 equal(lave(1, options), 'export default 1')


### PR DESCRIPTION
This PR adds an option to disable the crawling of the global scope.

I ran into issues because lave was unexpectedly adding references like `process.mainModule.children.1.children.0.children.5.children.3.children.0.exports.arguments.0` to the generated code. I assume this was a side-effect of using `babel-register` in my code, but even in other scenarios (when transferring data between systems) I think we can't assume a shared global context and need an option like this.
