### PR TITLE
obtain standard global props from fresh vm context

### DIFF
--- a/lave.js
+++ b/lave.js
@@ -413,8 +413,12 @@ function Globals() {
   return crawl(globals, (0, eval)('this'))
 }
 
+const STANDARD_GLOBALS = require('vm')
+  .runInNewContext('Object.getOwnPropertyNames(this)')
+  .concat('Buffer')
+
 function crawl(map, value, object) {
-  let names = Object.getOwnPropertyNames(value)
+  let names = object ? Object.getOwnPropertyNames(value) : STANDARD_GLOBALS
   let properties = []
 
   for (let name of names) {


### PR DESCRIPTION
As discussed in #21 this PR uses the vm module to obtain the standard V8 globals from a fresh context.
